### PR TITLE
Fix dependencies for HA 2025.2

### DIFF
--- a/custom_components/hcalory_ble/manifest.json
+++ b/custom_components/hcalory_ble/manifest.json
@@ -21,9 +21,9 @@
   "homekit": {},
   "iot_class": "local_polling",
   "requirements": [
-    "hcalory-control==0.1.5"
+    "hcalory-control==0.1.6"
   ],
   "ssdp": [],
   "zeroconf": [],
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "hcalory-ble"
-version = "0.1.1"
+version = "0.1.2"  # TODO sync HASS and project versions
 description = "Home Assistant custom integration for Hcalory BLE diesel heaters."
 authors = [{ name = "Evan Foster", email = "evan@fos.tech" }]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
   "aioesphomeapi>=27.0.2",
-  "hcalory-control==0.1.5",
-  "homeassistant>=2024.11.3",
+  "hcalory-control==0.1.6",
+  "homeassistant>=2025.2",
 ]
 
 [dependency-groups]
@@ -18,7 +18,7 @@ dev = [
     "home-assistant-bluetooth",
     "pytest-homeassistant-custom-component",
     # Requirements for HASS
-    "pyserial>=3.5",  # For HASS serial component
-    "bluetooth-auto-recovery>=1.4.2",  # For HASS Bluetooth component
+    "pyserial>=3.5", # For HASS serial component
+    "bluetooth-auto-recovery>=1.4.2", # For HASS Bluetooth component
 ]
 


### PR DESCRIPTION
HA 2025.2 updated the versions of bleak and bleak-retry-connector used. Our current versioning scheme is too restrictive, so we need to keep things manually up to date for now.

This should address issue #2.